### PR TITLE
change twitter card type to summary_large_image

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>ServerlessDays Austin</title>
+    <title>ServerlessDays ATX</title>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta http-equiv="Content-Language" content="en" />
@@ -11,7 +11,7 @@
     <meta property="og:description" content="A community based conference focusing on Serverless based platforms and technologies. Austin, 22 February 2019" />
     <meta property="og:url" content="https://atx.serverlessdays.io" />
     <meta property="og:image" content="https://upload.wikimedia.org/wikipedia/commons/0/06/AustinSkylineLouNeffPoint-2010-03-29-b.JPG" />
-    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@ATXServerless"/>
     <meta name="twitter:title" content="ServerlessDays Austin 2019"/>
     <meta name="twitter:description" content="A community based conference focusing on Serverless based platforms and technologies. Austin, 22 February 2019"/>


### PR DESCRIPTION
this is to have the twitter card work as an image card on twitter, per [this discussion](https://serverless-forum.slack.com/archives/GDEHC23BL/p1539630152000100?thread_ts=1539628857.000100&cid=GDEHC23BL) in slack.